### PR TITLE
ci: migrate image builds to Blacksmith Docker caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,6 @@ on:
 
 env:
   IMAGE_DESC: "Personal OS image based on Fedora Silverblue"
-  REGISTRY_USER: "${{ github.actor }}"
-  REGISTRY_PASSWORD: "${{ github.token }}"
   IMAGE_NAME: "${{ github.event.repository.name }}"
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
   GH_REPO: "${{ github.repository }}"
@@ -47,8 +45,6 @@ jobs:
   build_push:
     name: Build and push image
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    env:
-      PODMAN_BUILD_ARGS: "--cgroup-manager=cgroupfs --runtime=runc"
 
     permissions:
       contents: read
@@ -61,11 +57,48 @@ jobs:
         variant: ${{ fromJson(needs.variants.outputs.variants) }}
 
     steps:
-      - name: Checkout Push to Registry action
+      - name: Checkout
         uses: actions/checkout@v7
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
 
+      - name: Generate Containerfile
+        id: generate
+        run: |
+          output=$(bun script/generate-containerfile.ts ${{ matrix.variant }})
+          containerfile=$(echo "$output" | jq -r '.containerfile')
+          echo "containerfile=$containerfile" >> $GITHUB_OUTPUT
+
+          tags=$(echo "$output" | jq -r '.tags | join("\n")')
+          {
+            echo "tags<<EOF"
+            echo "$tags"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+          labels=$(echo "$output" | jq -r '.labels | join("\n")')
+          {
+            echo "labels<<EOF"
+            echo "$labels"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Builder
+        uses: useblacksmith/setup-docker-builder@v1
+
+      - name: Log in to container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
       - name: Build and push image
-        run: bun script/build-image.ts ${{ matrix.variant }}
+        uses: useblacksmith/build-push-action@v2
+        with:
+          context: .
+          file: ${{ steps.generate.outputs.containerfile }}
+          push: true
+          tags: ${{ steps.generate.outputs.tags }}
+          labels: ${{ steps.generate.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ dist
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# Generated Containerfiles for CI builds
+.generated/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ This repository uses direct Bun/TS commands (not package scripts).
 ### Build Commands
 - List variants: `bun script/list-variants.ts`
 - Resolve base image metadata: `bun script/get-base-image.ts <variant>`
-- Build (and optionally push) image: `bun script/build-image.ts <variant>`
+- Generate Containerfile for CI: `bun script/generate-containerfile.ts <variant>`
 - Run variant logic directly: `bun src/start-script.ts <variant>`
 
 ### Lint / Format / Typecheck
@@ -61,7 +61,7 @@ This repository uses direct Bun/TS commands (not package scripts).
 ## CI Behavior Summary
 - `build.yml`
   - computes variant matrix via `script/list-variants.ts`
-  - runs `bun script/build-image.ts <variant>` for each variant
+  - generates Containerfile via `script/generate-containerfile.ts`, then builds with Blacksmith Docker actions
 - `iso.yml`
   - installs dependencies with `bun install`
   - gets base image via `script/get-base-image.ts`
@@ -147,7 +147,7 @@ ISO upload-related:
 - `bunx tsc --noEmit` (for TS changes)
 - `bun script/list-variants.ts` (variant discovery changes)
 - `bun script/get-base-image.ts <variant>` (variant metadata changes)
-- `bun script/build-image.ts <variant>` (build-path changes)
+- `bun script/generate-containerfile.ts <variant>` (build-path changes)
 
 ## Commit Guidance
 - Keep commits focused and atomic.

--- a/script/generate-containerfile.ts
+++ b/script/generate-containerfile.ts
@@ -1,24 +1,16 @@
-import { $ } from "bun";
-import { exists, unlink, writeFile } from "fs/promises";
-import { tmpdir } from "os";
+import { exists, mkdir, writeFile } from "fs/promises";
 import { dirname, join } from "path";
 import { generateContainerfile } from "../src/utils/generate-containerfile";
 import { importVariantFromArgs } from "../src/utils/import-variant";
 
-const dir = dirname(__dirname);
+const repoRoot = dirname(__dirname);
 
 const { variantName, metadata, tasks } = await importVariantFromArgs();
 const taskNames = tasks.map((t) => t.name);
 const hasReadme = await exists(join(metadata.baseDirectory, "README.md"));
 
-const registryUser = process.env.REGISTRY_USER;
-const registryPassword = process.env.REGISTRY_PASSWORD;
-
 const imageNamePrefix = process.env.IMAGE_NAME?.toLocaleLowerCase() ?? "os";
 const imageRegistry = process.env.IMAGE_REGISTRY?.toLocaleLowerCase();
-const podmanBuildArgs = (process.env.PODMAN_BUILD_ARGS ?? "")
-  .split(/\s+/)
-  .filter(Boolean);
 
 const repo = process.env.GH_REPO;
 const commitSha = process.env.GITHUB_SHA?.slice(0, 7);
@@ -26,7 +18,7 @@ const refType = process.env.GH_REF_TYPE;
 const refName = process.env.GH_REF_NAME ?? "main";
 const prId = process.env.GH_PR;
 
-function getTags() {
+function getLocalTags() {
   const tags: string[] = [];
   tags.push(prId ? `pr-${prId}` : "latest");
   if (refType == "tag") tags.push(refName);
@@ -62,47 +54,30 @@ function getLabels() {
     ]);
   }
 
-  return labels.map((entry) => entry.join("="));
+  return labels.map(([key, value]) => `${key}=${value}`);
 }
 
-const tags = getTags();
-const labels = getLabels();
+function getRegistryTags(localTags: string[]) {
+  if (!imageRegistry) return localTags;
+  return localTags.map((tag) => `${imageRegistry}/${tag}`);
+}
 
 const baseImage = `quay.io/fedora-ostree-desktops/${metadata.baseImageName}:${metadata.baseImageVersion}`;
 
-const containerfilePath = join(
-  tmpdir(),
-  `os-containerfile-${variantName}-${Date.now()}`,
-);
+const containerfileRel = join(".generated", variantName, "Containerfile");
+const containerfilePath = join(repoRoot, containerfileRel);
 
+await mkdir(dirname(containerfilePath), { recursive: true });
 await writeFile(
   containerfilePath,
   generateContainerfile(baseImage, variantName, taskNames),
   "utf8",
 );
 
-try {
-  await $`
-    podman build \
-      --file=${containerfilePath} \
-      ${podmanBuildArgs} \
-      ${tags.map((tag) => ["--tag", tag])} \
-      ${labels.map((label) => ["--label", label])} \
-      ${dir}
-  `;
-} finally {
-  await unlink(containerfilePath);
-}
-
-if (imageRegistry && registryUser && registryPassword) {
-  await $`
-    podman login \
-      --username="${registryUser}" \
-      --password="${registryPassword}" \
-      ${imageRegistry}
-  `;
-
-  for (const tag of tags) {
-    await $`podman push ${tag} ${imageRegistry}/${tag}`;
-  }
-}
+console.log(
+  JSON.stringify({
+    containerfile: containerfileRel,
+    tags: getRegistryTags(getLocalTags()),
+    labels: getLabels(),
+  }),
+);


### PR DESCRIPTION
## Summary
- Replace podman build/push in `script/build-image.ts` with `script/generate-containerfile.ts`, which writes the Containerfile and outputs tags/labels as JSON for the workflow
- Update the Build workflow to use Blacksmith's `setup-docker-builder` and `build-push-action` for Docker layer caching
- Ignore generated `.generated/` Containerfiles in git

## Test plan
- [ ] Verify the Build workflow runs on this PR
- [ ] Confirm Containerfile generation succeeds for each matrix variant
- [ ] Confirm images build and push to GHCR with expected tags and labels
- [ ] Confirm subsequent runs reuse cached Docker layers


Made with [Cursor](https://cursor.com)